### PR TITLE
Fixes missing VARIANTTHEME.cfg

### DIFF
--- a/GameData/DaMichel/SphericalTanks/Parts/VariantThemes.cfg
+++ b/GameData/DaMichel/SphericalTanks/Parts/VariantThemes.cfg
@@ -1,0 +1,34 @@
+// Added to correct Log errors
+
+VARIANTTHEME
+{
+	name = Copper
+	displayName = Copper				//	#autoLOC_DMST_1701001
+	themeName = Copper
+	primaryColor = #aaaaaa
+	secondaryColor = #ffffff
+}
+VARIANTTHEME
+{
+	name = Bronze
+	displayName = Bronze				//	#autoLOC_DMST_1701002
+	themeName = Bronze
+	primaryColor = #aaaaaa
+	secondaryColor = #ffffff
+}
+VARIANTTHEME
+{
+	name = Aluminum
+	displayName = Aluminum				//	#autoLOC_DMST_1701003
+	themeName = Aluminum
+	primaryColor = #aaaaaa
+	secondaryColor = #ffffff
+}
+VARIANTTHEME
+{
+	name = NettedCarbonFiber
+	displayName = NettedCarbonFiber		//	#autoLOC_DMST_1701004
+	themeName = NettedCarbonFiber
+	primaryColor = #aaaaaa
+	secondaryColor = #ffffff
+}


### PR DESCRIPTION
[ERR 12:49:18.247] Unable to find theme named:'Copper' in GameDB
[ERR 12:49:18.247] Unable to find theme named:'Bronze' in GameDB
[ERR 12:49:18.247] Unable to find theme named:'Aluminum' in GameDB
[ERR 12:49:18.247] Unable to find theme named:'NettedCarbonFiber' in GameDB